### PR TITLE
Fix `attempt to call local 'room' (a string value)`

### DIFF
--- a/mod_muc_restrict_rooms.lua
+++ b/mod_muc_restrict_rooms.lua
@@ -21,7 +21,7 @@ local function is_restricted(room, who)
 
 	-- Don't evaluate exceptions
 	if restrict_excepts:contains(room) then
-		module:log("debug", "Room %s is amongst restriction exceptions", room())
+		module:log("debug", "Room %s is amongst restriction exceptions", room)
 		return nil;
 	end
 


### PR DESCRIPTION
 Traceback[c2s]: /usr/lib/prosody/modules/mod_muc_restrict_rooms.lua:24: attempt to call local 'room' (a string value)